### PR TITLE
Added a typedef file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.4.14",
   "description": "Creates toast messages",
   "main": "lib/toast-me.min.js",
+  "types": "toast-me.d.ts",
   "scripts": {
     "build": "webpack --env build --config scripts/config/webpack.config.prod.js",
     "run-dev": "node scripts/dev-server",

--- a/toast-me.d.ts
+++ b/toast-me.d.ts
@@ -1,0 +1,10 @@
+import { ToastMeClass } from './src';
+import { ToastActionType, ToastOptionsType } from './src/types';
+
+declare module 'toast-me' {
+  export function toast(
+    content: string,
+    receivedOptions: undefined | null | ToastOptionsType | 'error' | 'notify' = 'notify',
+    action: undefined | ToastActionType
+  ): ToastMeClass
+}

--- a/toast-me.d.ts
+++ b/toast-me.d.ts
@@ -4,7 +4,7 @@ import { ToastActionType, ToastOptionsType } from './src/types';
 declare module 'toast-me' {
   export function toast(
     content: string,
-    receivedOptions: undefined | null | ToastOptionsType | 'error' | 'notify' = 'notify',
-    action: undefined | ToastActionType
+    receivedOptions?: null | ToastOptionsType | 'error' | 'notify' = 'notify',
+    action?: ToastActionType
   ): ToastMeClass
 }

--- a/toast-me.d.ts
+++ b/toast-me.d.ts
@@ -2,7 +2,7 @@ import { ToastMeClass } from './src';
 import { ToastActionType, ToastOptionsType } from './src/types';
 
 declare module 'toast-me' {
-  export function toast(
+  export default function toast(
     content: string,
     receivedOptions?: null | ToastOptionsType | 'error' | 'notify' = 'notify',
     action?: ToastActionType

--- a/toast-me.d.ts
+++ b/toast-me.d.ts
@@ -4,7 +4,7 @@ import { ToastActionType, ToastOptionsType } from './src/types';
 declare module 'toast-me' {
   export default function toast(
     content: string,
-    receivedOptions?: null | ToastOptionsType | 'error' | 'notify' = 'notify',
+    receivedOptions?: null | ToastOptionsType | 'error' | 'notify',
     action?: ToastActionType
   ): ToastMeClass
 }


### PR DESCRIPTION
Hey, added a simple typedef file to get typings for the function exported by this lib.

I am not familiar with flowtype or your webpack build system so I don't feel comfortable attempting https://github.com/a-kalinin/toast-me/issues/52 but this should work until you get around to it.

I tested it and it seems to stop the `error TS7016: Could not find a declaration file for module 'toast-me'.` messages from the typescript compiler.

Hope to get this merged and released soon.